### PR TITLE
Clean up self._filehandle() in Pygtail.__del__

### DIFF
--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -56,6 +56,10 @@ class Pygtail(object):
                 # Look for the rotated file and process that if we find it.
                 self._rotated_logfile = self._determine_rotated_logfile()
 
+    def __del__(self):
+        if self._filehandle():
+            self._filehandle().close()
+
     def __iter__(self):
         return self
 


### PR DESCRIPTION
eliminates warnings when running tests in Python 3.2:

```
test_logrotate (pygtail.test.test_pygtail.PygtailTest) ... /Users/marc/dev/git-repos/pygtail/pygtail/test/test_pygtail.py:60: ResourceWarning: unclosed file <_io.TextIOWrapper name='/var/folders/EV/EVpZ2D-dFr0Q0VP8cVxFc++++TI/-Tmp-/tmpq_86j3' mode='r' encoding='UTF-8'>
  pygtail = Pygtail(self.logfile.name)
/usr/local/Cellar/python3/3.2.3/lib/python3.2/unittest/case.py:370: ResourceWarning: unclosed file <_io.TextIOWrapper name='/var/folders/EV/EVpZ2D-dFr0Q0VP8cVxFc++++TI/-Tmp-/tmpq_86j3' mode='r' encoding='UTF-8'>
  function()
ok
test_read (pygtail.test.test_pygtail.PygtailTest) ... /usr/local/Cellar/python3/3.2.3/lib/python3.2/unittest/case.py:370: ResourceWarning: unclosed file <_io.TextIOWrapper name='/var/folders/EV/EVpZ2D-dFr0Q0VP8cVxFc++++TI/-Tmp-/tmpjh32i4' mode='r' encoding='UTF-8'>
  function()
ok
test_readlines (pygtail.test.test_pygtail.PygtailTest) ... /usr/local/Cellar/python3/3.2.3/lib/python3.2/unittest/case.py:370: ResourceWarning: unclosed file <_io.TextIOWrapper name='/var/folders/EV/EVpZ2D-dFr0Q0VP8cVxFc++++TI/-Tmp-/tmpxpo6vm' mode='r' encoding='UTF-8'>
  function()
ok
test_subsequent_read_with_new_data (pygtail.test.test_pygtail.PygtailTest) ... /usr/local/Cellar/python3/3.2.3/lib/python3.2/unittest/case.py:370: ResourceWarning: unclosed file <_io.TextIOWrapper name='/var/folders/EV/EVpZ2D-dFr0Q0VP8cVxFc++++TI/-Tmp-/tmp2ur1g0' mode='r' encoding='UTF-8'>
  function()
ok
test_subsequent_read_with_no_new_data (pygtail.test.test_pygtail.PygtailTest) ... /usr/local/Cellar/python3/3.2.3/lib/python3.2/unittest/case.py:370: ResourceWarning: unclosed file <_io.TextIOWrapper name='/var/folders/EV/EVpZ2D-dFr0Q0VP8cVxFc++++TI/-Tmp-/tmpadd2bf' mode='r' encoding='UTF-8'>
  function()
ok
```
