### PR TITLE
add parsing support of TimedRotatingFileHandler

### DIFF
--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -168,6 +168,12 @@ class Pygtail(object):
             candidates.sort()
             return candidates[-1]  # return most recent
 
+        # for TimedRotatingFileHandler
+        candidates = glob.glob("%s.[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]" % self.filename)
+        if candidates:
+            candidates.sort()
+            return candidates[-1]  # return most recent
+
         # no match
         return None
 


### PR DESCRIPTION
Hi, bgreenlee
Recently I use pygtail in my project and found pygtail couldn't handle the log like 'mylog.2013-08-20', which, 
is generated by TimedRotatingFileHandler of python. So I added the format parsing to correct this.
Will it be useful?
