### PR TITLE
Python 3 compatibility

### DIFF
--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -255,7 +255,7 @@ def main():
     options, args = cmdline.parse_args()
 
     if options.version:
-        print "pygtail version %s" % __version__
+        print("pygtail version", __version__)
         sys.exit(0)
 
     if (len(args) != 1):


### PR DESCRIPTION
Converts a print statement to the python 3 compatible print() function. Tests now pass.