### PR TITLE
Use readline instead of next to get next line

### DIFF
--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -92,7 +92,7 @@ class Pygtail(object):
         Return the next line in the file, updating the offset.
         """
         try:
-            line = next(self._filehandle())
+            line = self._get_next_line()
         except StopIteration:
             # we've reached the end of the file; if we're processing the
             # rotated log file, we can continue with the actual file; otherwise
@@ -103,7 +103,7 @@ class Pygtail(object):
                 self._offset = 0
                 # open up current logfile and continue
                 try:
-                    line = next(self._filehandle())
+                    line = self._get_next_line()
                 except StopIteration:  # oops, empty file
                     self._update_offset_file()
                     raise
@@ -236,6 +236,11 @@ class Pygtail(object):
         # no match
         return None
 
+    def _get_next_line(self):
+        line = self._filehandle().readline()
+        if not line:
+            raise StopIteration
+        return line
 
 def main():
     # command-line parsing

--- a/pygtail/test/test_pygtail.py
+++ b/pygtail/test/test_pygtail.py
@@ -132,6 +132,28 @@ class PygtailTest(unittest.TestCase):
     def test_copytruncate_larger_on(self):
         self._test_copytruncate_larger(True)
 
+    def test_offset_file(self):
+        pygtail = Pygtail(self.logfile.name, paranoid=True)
+
+        log_inode = os.stat(self.logfile.name).st_ino
+
+        next(pygtail)
+        with open(self.logfile.name + '.offset', 'r') as f:
+            inode, offset = int(next(f)), int(next(f))
+        self.assertEqual(inode, log_inode)
+        self.assertEqual(offset, 2)
+
+        next(pygtail)
+        with open(self.logfile.name + '.offset', 'r') as f:
+            inode, offset = int(next(f)), int(next(f))
+        self.assertEqual(inode, log_inode)
+        self.assertEqual(offset, 4)
+
+        next(pygtail)
+        with open(self.logfile.name + '.offset', 'r') as f:
+            inode, offset = int(next(f)), int(next(f))
+        self.assertEqual(inode, log_inode)
+        self.assertEqual(offset, 6)
 
 def main():
     unittest.main(buffer=True)


### PR DESCRIPTION
Fix the problem that offset file does not contain correct offset due to look ahead buffer optimization in python.