### PR TITLE
Fix Python 3 compatibility and remove parentheses in --version

### DIFF
--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -22,6 +22,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
+from __future__ import print_function
 from os import stat
 from os.path import exists, getsize
 import sys

--- a/pygtail/test/test_pygtail.py
+++ b/pygtail/test/test_pygtail.py
@@ -106,7 +106,8 @@ class PygtailTest(unittest.TestCase):
         captured_value = captured.getvalue()
         sys.stderr = sys.__stderr__
 
-        self.assertRegexpMatches(captured_value, r".*?\bWARN\b.*?\bshrank\b.*")
+        assert_class = self.assertRegex if sys.version_info >= (3, 1) else self.assertRegexpMatches
+        assert_class(captured_value, r".*?\bWARN\b.*?\bshrank\b.*")
         self.assertEqual(pygtail.read(), None)
 
     def test_copytruncate_on_smaller(self):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ def main():
     setup(
         name = 'pygtail',
         version = __version__,
-        use_2to3=True,
         description = 'Reads log file lines that have not been read.',
         license = 'GPL v2',
         author = 'Brad Greenlee',


### PR DESCRIPTION
Hi, the module currently doesn't work with Python 3 although the tests are succcessful. This is caused by 2to3 which renames `next` to `__next__` even though the latter already exists.
I removed 2to3 from `setup()` since the code already works with both versions.
I also imported `print_function` to prevent `print("pygtail version", __version__)` from displaying `("pygtail version", "0.5.2")` with Python 2.
This import works with Python >= 2.6 so it not be an issue for anyone using a recent enough system.
I also fixed a deprecation warning in one of the tests.
Please let me know if you need me to change anything to my fork before merging it.