### PR TITLE
if we fail to find the rotated file, still set offset back to 0

### DIFF
--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -76,10 +76,14 @@ class Pygtail(object):
             offset_fh.close()
             if self._offset_file_inode != stat(self.filename).st_ino or \
                     stat(self.filename).st_size < self._offset:
-                # The inode has changed or filesize has reduced so the file
-                # might have been rotated.
+                # The inode has changed or filesize has reduced so we will
+                # assume the file rotated.
                 # Look for the rotated file and process that if we find it.
                 self._rotated_logfile = self._determine_rotated_logfile()
+                # If we failed to find the rotated file, we should set our
+                # offset to 0 and process the existing file from there.
+                if not self._rotated_logfile:
+                    self._offset = 0
 
     def __del__(self):
         if self._filehandle():


### PR DESCRIPTION
We ran across an issue in the case where a logfile rotates, but Pygtail cannot find it.  At that point it never starts parsing the new file - after each iteration of calling Pygtail in our script, it would parse 0 lines and update the offset file with the new logfile's inode, but the old (rotated) file's offset, and of course the new logfile's length was consistently less than the rotated one since it had been around for a lot less time.

The fix here works for us, but a better one might distinguish between the two cases where self._rotated_logfile is None (both in the normal case where nothing rotated, and the exception case where the log rotated, but _determine_rotated_logfile came up empty).
