### PR TITLE
Add hooks around updating the offset file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ From the command line:
       -p, --paranoid        Update the offset file every time we read a line
                             (as opposed to only when we reach the end of the
                             file).
+      -n N, --every-n=N     Update the offset file every N'th time we read a
+                            line (as opposed to only when we reach the end of
+                            the file).
       --no-copytruncate     Don't support copytruncate-style log rotation.
                             Instead, if the log file shrinks, print a warning.
 

--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -288,7 +288,7 @@ def main():
     pygtail = Pygtail(args[0],
                       offset_file=options.offset_file,
                       paranoid=options.paranoid,
-                      every_n=options.every_n
+                      every_n=options.every_n,
                       copytruncate=not options.no_copytruncate)
 
     for line in pygtail:


### PR DESCRIPTION
This change does three things:

1. Add on_update run a command every time the offset file is updated.
2. Add every_n to cause the offset file to update every_n lines.
3. Add unit tests that cover this, and the existing paranoid flag.

I need this for a job that follows log files and inserts them into a database.  I want to be able to commit to the database every time the offset file is written, and be able to guarantee committing every 100 lines to ensure regular progress if I'm processing a large file.