### PR TITLE
Fix issue #20 by adding line buffering

### DIFF
--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -168,9 +168,9 @@ class Pygtail(object):
         if not self._fh or self._is_closed():
             filename = self._rotated_logfile or self.filename
             if filename.endswith('.gz'):
-                self._fh = gzip.open(filename, 'r')
+                self._fh = gzip.open(filename, "r", 1)
             else:
-                self._fh = open(filename, "r")
+                self._fh = open(filename, "r", 1)
             self._fh.seek(self._offset)
 
         return self._fh

--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -168,7 +168,7 @@ class Pygtail(object):
         if not self._fh or self._is_closed():
             filename = self._rotated_logfile or self.filename
             if filename.endswith('.gz'):
-                self._fh = gzip.open(filename, "r", 1)
+                self._fh = gzip.open(filename, 'r')
             else:
                 self._fh = open(filename, "r", 1)
             self._fh.seek(self._offset)


### PR DESCRIPTION
Adding line buffering when opening log file ensures you only read complete lines. Fixes issue #20 