### PR TITLE
Test renamecreate also when file is rotated to unknown (to pytgail) n…

### DIFF
--- a/pygtail/test/test_pygtail.py
+++ b/pygtail/test/test_pygtail.py
@@ -294,6 +294,23 @@ class PygtailTest(unittest.TestCase):
         self.append(new_lines[1])
         self.assertEqual(pygtail.read(), ''.join(new_lines))
 
+    def test_renamecreate_unknown_rotated_name(self):
+        """
+        Tests "renamecreate" semantics where the currently processed file gets renamed and the
+        original file gets recreated. Rolled file has unknown name to pygtail. logrotate from
+        Linux has this behaviour when rotating into separate directory.
+        """
+        new_lines = ["4\n5\n", "6\n7\n"]
+        pygtail = Pygtail(self.logfile.name)
+        pygtail.read()
+        os.rename(self.logfile.name, "%s.unknown-name" % self.logfile.name)
+        # append will recreate the original log file
+        self.append(new_lines[0])
+        self.append(new_lines[1])
+        # reopen using Pytgail
+        pygtail = Pygtail(self.logfile.name)
+        self.assertEqual(pygtail.read(), ''.join(new_lines))
+
 
 def main():
     unittest.main(buffer=True)


### PR DESCRIPTION
…ame and pygtail is freshly reading file.

This test is testing a case when:
- logrotate (https://github.com/logrotate/logrotate) rotates file to some unknown file name (in real life scenario it rotates the file to different "archive/" directory
- log file gets new entries
- some new run of script uses pygail to read log file (that's why I'm "reopening" file using new pytgail object)

**Currently pygtail is failing this test suite due to bug in pygtail not handling such case.**