### PR TITLE
Fix race condition in `_update_offset_file()`

### DIFF
--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -191,7 +191,7 @@ class Pygtail(object):
         if self.on_update:
             self.on_update()
         offset = self._filehandle().tell()
-        inode = stat(self.filename).st_ino
+        inode = fstat(self._filehandle().fileno()).st_ino
         fh = open(self._offset_file, "w")
         fh.write("%s\n%s\n" % (inode, offset))
         fh.close()


### PR DESCRIPTION
When file rotation happens during tailing `_update_offset_file` writes inode of a new file instead of old one but offset is taken from the old file