### PR TITLE
🐛 Open gziped files in text mode

### DIFF
--- a/pygtail/core.py
+++ b/pygtail/core.py
@@ -245,7 +245,7 @@ class Pygtail(object):
             self._counter += 1
             filename = self.rotated_logfile or self.filename
             if filename.endswith('.gz'):
-                self.fh = gzip.open(filename, 'r')
+                self.fh = gzip.open(filename, 'rt')
             elif PY3:
                 self.fh = open(filename, "r", 1, encoding=self.encoding)
             else:

--- a/pygtail/test/test_pygtail.py
+++ b/pygtail/test/test_pygtail.py
@@ -405,6 +405,26 @@ class PygtailTest(unittest.TestCase):
             self.assertGreaterEqual(offsets[i], offsets[i])
             self.assertGreaterEqual(offsets[i+1], offsets[i])
 
+    def test_compressed_full_lines(self):
+        new_lines = ["4\n5\n", "6\n7\n"]
+        pygtail = Pygtail(self.logfile.name, full_lines=True)
+        pygtail.read()
+        self.append(new_lines[0])
+
+        # put content to gzip file
+        gzip_handle = gzip.open("%s.1.gz" % self.logfile.name, 'wb')
+        with open(self.logfile.name, 'rb') as logfile:
+            gzip_handle.write(logfile.read())
+        gzip_handle.close()
+
+        with open(self.logfile.name, 'w'):
+            # truncate file
+            pass
+
+        self.append(new_lines[1])
+        pygtail = Pygtail(self.logfile.name, full_lines=True)
+        self.assertEqual(pygtail.read(), ''.join(new_lines))
+
 def main():
     unittest.main(buffer=True)
 


### PR DESCRIPTION
When using `gzip.open`, the mode `r` means `rb`. We want to open the file in text mode, so we have to use `rt`. Otherwise this lead to crashes if the files is opened with `full_lines=True`